### PR TITLE
After this detail having wasted many hours of my time over the years …

### DIFF
--- a/machines/kill-child-process.js
+++ b/machines/kill-child-process.js
@@ -106,7 +106,7 @@ module.exports = {
     forceKillOrGiveUp = function (){
       try {
         // Remove the `close` listener from the child process, so that it's not called later
-        // if that signal comes in belatedly.
+        // if that signal comes in belatedly.  (And so we don't leave dangling listeners hanging around.)
         inputs.childProcess.removeListener('close', handleClosingChildProc);
 
         // If `forceIfNecessary` is on, attempt to send a SIGKILL to the process,
@@ -137,6 +137,10 @@ module.exports = {
         return;
       }
 
+      // Remove the `close` listener from the child process, so that we don't leave any
+      // event listeners dangling.
+      inputs.childProcess.removeListener('close', handleClosingChildProc);
+
       // Clear the timeout timer.
       clearTimeout(timer);
 
@@ -161,7 +165,7 @@ module.exports = {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     // Listen for the child process being closed.
-    inputs.childProcess.on('close', handleClosingChildProc);
+    inputs.childProcess.once('close', handleClosingChildProc);
 
     // Set a timer.
     // (If the child process has not closed gracefully after `inputs.maxMsToWait`,

--- a/machines/spawn-child-process.js
+++ b/machines/spawn-child-process.js
@@ -25,7 +25,7 @@ module.exports = {
 
     command: {
       description: 'The command to run in the child process, without any CLI arguments or options.',
-      extendedDescription: 'Node core is tolerant of CLI args mixed in with the main "command" in `child_process.exec()`, but it is not so forgiving when using `child_process.spawn()`.',
+      extendedDescription: 'Node core is tolerant of CLI args mixed in with the main "command" in `child_process.exec()`, but it is not so forgiving when using `child_process.spawn()`.  That means you cannot provide a command like "git commit" this way.  Instead, provide "git" as the command and `["commit"]` as the CLI args.',
       example: 'ls',
       required: true
     },
@@ -78,7 +78,14 @@ module.exports = {
     // Import `lodash`.
     var _ = require('lodash');
 
-    // First, build up the options to pass in to `child_process.spawn()`.
+    // First, validate that the provided command is valid.
+    // `child_process.spawn()` has some pretty harsh limitations here,
+    // and since this interface is so low level, it's really easy to mess up.
+    if (inputs.command.match(/\s/)) {
+      return exits.error(new Error('The string provided to spawnChildProcess() for the `command` input ("'+inputs.command+'") is not valid.  Unlike `executeCommand()` (the simpler, higher-level machine), the `command` provided to `spawnChildProcess()` should never contain spaces!  To spawn a child process with a command like `git commit`, send in "git" as the command, and `["commit", "-am", "foo"]` as the CLI args.'));
+    }
+
+    // Now build up the options to pass in to `child_process.spawn()`.
     var childProcOpts = {};
 
     // Determine the appropriate `cwd` for `child_process.exec()`.

--- a/tests/spawn-child-process.test.js
+++ b/tests/spawn-child-process.test.js
@@ -142,13 +142,44 @@ describe('spawnChildProcess()', function (){
 
 
 
+  describe('if spaces are used in the command', function (){
+    this.slow(1500);
+
+    var childProc;
+    it('should fail with an error', function (done){
+
+      try {
+        childProc = Pack.spawnChildProcess({
+          command: 'blah blah, space separated args arent allowed see',
+        }).execSync();
+      }
+      catch (e) {
+        return done();
+      }
+
+      return done(new Error('Should have failed w/ an error!'));
+    });
+
+    after(function (done) {
+      if (!childProc) { return done(); }
+
+      Pack.killChildProcess({
+        childProcess: childProc,
+        forceIfNecessary: true
+      }).exec(done);
+    });
+
+  });//</if spaces are used in the command>
+
+
   describe('if the child process emits an error', function (){
     this.slow(1500);
 
     var childProc;
     it('should not crash the process', function (done){
       childProc = Pack.spawnChildProcess({
-        command: 'blah blah, space separated args arent allowed see, so this will be emitting errors for sure!!!!',
+        command: 'node',
+        cliArgs: ['-e', 'throw new Error(\'oops\');'],
       }).execSync();
       // We wait another few moments just to be 100% sure.
       setTimeout(function (){


### PR DESCRIPTION
…(more times than I can count w/ node core, and twice now w/ mp-processes), I think this finally protects people like me from ourselves; once and for all.  This validates the provided command string in 'spawnChildProcess()' to prevent it from being used if it has any spaces.  Because it won't work... and it will fail silently.  Leaving you lost and cold.  This commit also expands the relevant metadata.
