### PR TITLE
Remove machinepack-json dependency to resolve vulnerabilities

### DIFF
--- a/lib/escape-as-command-line-opt.js
+++ b/lib/escape-as-command-line-opt.js
@@ -58,12 +58,7 @@ module.exports = {
 
   fn: function (inputs,exits) {
 
-    // Import `lodash`.
     var _ = require('@sailshq/lodash');
-
-    // Import `machinepack-json`.
-    var MPJSON = require('machinepack-json');
-
 
     // First, determine the string to escape.
     var stringToEscape;

--- a/lib/escape-as-command-line-opt.js
+++ b/lib/escape-as-command-line-opt.js
@@ -75,7 +75,53 @@ module.exports = {
     else {
       // Attempt to stringify the value.
       try {
-        stringToEscape = MPJSON.stringifySafe({value:inputs.value}).execSync();
+        // This was modified by @mikermcneil from @isaacs' json-stringify-safe
+        // (see https://github.com/isaacs/json-stringify-safe/commit/02cfafd45f06d076ac4bf0dd28be6738a07a72f9#diff-c3fcfbed30e93682746088e2ce1a4a24)
+        function serializer() {
+          var stack = [];
+          var keys = [];
+
+          // Function to replace circular references with a string describing the reference.
+          // Used by the custom stringify function below.
+          var cycleReplacer = function(key, value) {
+            if (stack[0] === value) {
+              return '[Circular ~]';
+            }
+            return '[Circular ~.' + keys.slice(0, stack.indexOf(value)).join('.') + ']';
+          };
+
+          // Return a custom stringify function to be used as the second argument
+          // to the native JSON.stringify.
+          return function(key, value) {
+            if (stack.length > 0) {
+              var thisPos = stack.indexOf(this);
+              ~thisPos ? stack.splice(thisPos + 1) : stack.push(this);
+              ~thisPos ? keys.splice(thisPos, Infinity, key) : keys.push(key);
+              if (~stack.indexOf(value)) {
+                value = cycleReplacer.call(this, key, value);
+              }
+            }
+            else {
+              stack.push(value);
+            }
+
+            // Do some advanced serialization
+            if (_.isError(value)){
+              value = value.stack;
+            }
+            else if (_.isRegExp(value)){
+              value = value.toString();
+            }
+            else if (_.isFunction(value)){
+              value = value.toString();
+            }
+
+            return value;
+          };
+        }
+
+        // Serialize the string.
+        stringToEscape = JSON.stringify(inputs.value, serializer());
       } catch (e) {
         // If we couldn't stringify the value, exit through the `couldNotSerialize` exit.
         if (e.code === 'E_MACHINE_RUNTIME_VALIDATION') {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",
     "machine": "^15.0.0-23",
-    "machinepack-json": "^2.0.0",
     "opn": "5.3.0"
   },
   "devDependencies": {

--- a/test/escape-as-command-line-opt.json5
+++ b/test/escape-as-command-line-opt.json5
@@ -8,7 +8,7 @@
         "value": 4
       },
       "outcome": "success",
-      "returns": "4"
+      "returns": "\"4\""
     },
 
     // Boolean
@@ -17,7 +17,7 @@
         "value": true
       },
       "outcome": "success",
-      "returns": "true"
+      "returns": "\"true\""
     },
 
     // Basic string

--- a/test/escape-as-command-line-opt.json5
+++ b/test/escape-as-command-line-opt.json5
@@ -8,7 +8,7 @@
         "value": 4
       },
       "outcome": "success",
-      "returns": "\"4\""
+      "returns": "4"
     },
 
     // Boolean
@@ -17,7 +17,7 @@
         "value": true
       },
       "outcome": "success",
-      "returns": "\"true\""
+      "returns": "true"
     },
 
     // Basic string


### PR DESCRIPTION
Because the machinepack-json repo has been archived and it's only in one place, I just brought the logic from its `stringifySafe` machine inline and switched it to use @sailshq/lodash there. Tested the change in the node repl with `require('./').escapeAsCommandLineOpt(...)` and got the expected result from any values I passed in. Also tested it linked to my local sails-generate (which I then used to generate a new app) just for a sanity check, and the code from machinepack-process ran just peachily. So, this shouldn't be a breaking change at all.